### PR TITLE
Base Matchers

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,6 +218,49 @@ console.log(ninja.getArsenal('ninja stars', 'balloons'));
 ```
 Since all when arguments were provided (i.e. `'ninja stars'`) it doesn't matter that we also pass in balloons. This is particularly useful if you are mocking asynchronous functions because you do not have to specify the callback but it will still match.
 
+### Matchers
+Matchers allow you to pass in 'fuzzy' arguments to a when. This allows for more generic stubbing.
+
+#### Usage Example
+```js
+import {mockFunction, matchers} from 'mockolate';
+const ninja = {
+  getArsenal: mockFunction()
+};
+ninja.getArsenal.when(matchers.any()).thenReturn('1 star');
+console.log(ninja.getArsenal('anything at all'));
+//Result will be '1 star' since matchers.any() matches anything.
+```
+
+#### AnyMatcher
+Matches anything passed into that argument.
+
+```js
+import {mockFunction, matchers} from 'mockolate';
+const ninja = {
+  getArsenal: mockFunction()
+};
+ninja.getArsenal.when(matchers.any()).thenReturn('1 star');
+console.log(ninja.getArsenal('anything at all'));
+//Result will be '1 star' since matchers.any() matches anything.
+```
+
+#### ExactMatcher
+Matches if any only if what is passed into the matcher is exactly equal to the invocation argument. Passing `null` or `undefined` into the ExactMatcher will never match.
+
+```js
+import {mockFunction, matchers} from 'mockolate';
+const ninja = {
+  getArsenal: mockFunction()
+};
+ninja.getArsenal.when(matchers.exact(1)).thenReturn('1 star');
+console.log(ninja.getArsenal(1));
+//Result will be '1 star' since 1 exactly equals 1.
+ninja.getArsenal.when(matchers.exact(null)).thenReturn('2 stars');
+console.log(ninja.getArsenal('anything at null'));
+//Result will never be '2 stars' since null and undefined never match anything exactly.
+```
+
 ### Specificity
 Whens match from most specific to least specific. That means if you give it a really general when like `when()` it will only match if no other whens match first.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mockolate",
-  "version": "1.0.4",
+  "version": "1.1.0",
   "description": "Simple mocking framework for JS",
   "main": "dist/index.js",
   "scripts": {

--- a/src/index.js
+++ b/src/index.js
@@ -1,3 +1,9 @@
 import mockFunction from './mock/mockFunc';
+import {any, exact} from './matchers';
+const matchers = {
+  any,
+  exact
+};
 
-export {mockFunction};
+export {mockFunction, matchers};
+export default mockFunction;

--- a/src/matchers/any.js
+++ b/src/matchers/any.js
@@ -1,0 +1,14 @@
+import Matcher from './matcher';
+class AnyMatcher extends Matcher {
+  constructor(){
+    super();
+  }
+  matches(){
+    return true;
+  }
+};
+
+export {
+  AnyMatcher
+};
+export default () => new AnyMatcher();

--- a/src/matchers/exact.js
+++ b/src/matchers/exact.js
@@ -1,0 +1,24 @@
+import Matcher from './matcher';
+class ExactMatcher extends Matcher {
+  constructor(value){
+    super();
+    this.value = value;
+  }
+  matches(otherValue) {
+    if (!this.value) {
+      return false;
+    }
+    if (this.value === otherValue) {
+      return true;
+    }
+    if (this.value.equals) {
+      return this.value.equals(otherValue);
+    }
+    return false;
+  }
+}
+
+export {
+  ExactMatcher
+};
+export default (valueToMatch) => new ExactMatcher(valueToMatch);

--- a/src/matchers/index.js
+++ b/src/matchers/index.js
@@ -1,0 +1,8 @@
+import any from './any';
+import exact from './exact';
+import Matcher from './matcher';
+export {
+  Matcher,
+  any,
+  exact
+};

--- a/src/matchers/matcher.js
+++ b/src/matchers/matcher.js
@@ -1,0 +1,9 @@
+class Matcher {
+  constructor(){
+  }
+  matches() {
+    return true;
+  }
+};
+
+export default Matcher;

--- a/src/when/when.js
+++ b/src/when/when.js
@@ -1,4 +1,6 @@
 import _ from 'lodash';
+import { Matcher, exact } from '../matchers';
+
 class When {
   constructor(mockedFunction, args){
     if(!mockedFunction){
@@ -39,14 +41,10 @@ class When {
     const argsToMatch = arguments || [];
     let allMatch = this.args.every((arg, index) => {
       let argToMatch = argsToMatch[index];
-      //If args is a matcher then invoke its matchiness.
-      if(arg.equals){
-        return arg.equals(argToMatch);
+      if(arg instanceof Matcher){
+        return arg.matches(argToMatch);
       }
-      if(_.get(argToMatch, 'equals')){
-        return argToMatch.equals(arg);
-      }
-      return arg === argToMatch;
+      return exact(arg).matches(argToMatch);
     });
     return allMatch;
   }

--- a/test/index.js
+++ b/test/index.js
@@ -1,0 +1,25 @@
+import mockFunc, {mockFunction, matchers} from '../src';
+import {expect} from 'chai';
+
+describe('mockolate', () => {
+  it('should export mockFunction', () => {
+    expect(mockFunction).to.be.ok;
+  });
+
+  it('should export mock function as the default', () => {
+    expect(mockFunc).to.be.ok;
+    expect(mockFunc).to.equal(mockFunction);
+  });
+
+  describe('matchers', () => {
+    it('should expose the any matcher', () => {
+      expect(matchers).be.ok;
+      expect(matchers.any).to.be.ok;
+    });
+
+    it('should expose the exact matcher', () => {
+      expect(matchers).to.be.ok;
+      expect(matchers.exact).to.be.ok;
+    });
+  });
+});

--- a/test/matchers/any.js
+++ b/test/matchers/any.js
@@ -1,0 +1,18 @@
+import any from '../../src/matchers/any';
+import { expect } from 'chai';
+import Matcher from '../../src/matchers/matcher';
+
+describe('any matcher', () => {
+  it('should always return true for matches', () => {
+    const anyMatcher = any();
+    const matchesRandom = anyMatcher.matches(1, 'a', 1.5, {}, []);
+    expect(matchesRandom).to.equal(true);
+    const matchesNothing = anyMatcher.matches();
+    expect(matchesNothing).to.equal(true);
+  });
+
+  it('should return an instance of matcher', () => {
+    const anyMatcher = any();
+    expect(anyMatcher).to.be.instanceof(Matcher);
+  });
+});

--- a/test/matchers/exact.js
+++ b/test/matchers/exact.js
@@ -1,0 +1,43 @@
+import exact from '../../src/matchers/exact';
+import Matcher from '../../src/matchers/matcher';
+import {expect} from 'chai';
+
+describe('exact matcher', () => {
+  it('should return an instance of Matcher', () => {
+    const matcher = exact(1);
+    expect(matcher).to.be.instanceof(Matcher);
+  });
+
+  it('should return true if both values are exactly the same', () => {
+    const value = 2;
+    const matcher = exact(value);
+    expect(matcher.matches(value)).to.equal(true);
+  });
+
+  it('should return true if both values are ===', () => {
+    const string1 = 'a';
+    const string2 = 'a';
+    const matcher = exact(string1);
+    expect(matcher.matches(string2)).to.equal(true);
+  });
+
+  it('should return true if the value has an equals method that returns true', () => {
+    const object = {
+      equals: () => true
+    };
+    const matcher = exact(object);
+    expect(matcher.matches(1234)).to.equal(true);
+  });
+
+  it('should return false if the value is null or undefined', () => {
+    const nullMatcher = exact(null);
+    const undefinedMatcher = exact(undefined);
+    expect(nullMatcher.matches(null)).to.equal(false);
+    expect(undefinedMatcher.matches()).to.equal(false);
+  });
+
+  it('should return false if the two values are not equal', () => {
+    const matcher = exact(1);
+    expect(matcher.matches(2)).to.equal(false);
+  });
+});

--- a/test/matchers/index.js
+++ b/test/matchers/index.js
@@ -1,0 +1,16 @@
+import * as Matchers from '../../src/matchers/index';
+import { expect } from 'chai';
+
+describe('matchers', () => {
+  it('should expose the Matcher object', () => {
+    expect(Matchers.Matcher).to.be.ok;
+  });
+
+  it('should expose an any matcher', () => {
+    expect(Matchers.any).to.be.ok;
+  });
+
+  it('should expose an exact matcher', () => {
+    expect(Matchers.exact).to.be.ok;
+  });
+});

--- a/test/when/when.js
+++ b/test/when/when.js
@@ -3,6 +3,7 @@ import {
   expect
 } from 'chai';
 import _ from 'lodash';
+import {exact, any} from '../../src/matchers';
 
 describe('when class', () => {
   const mockFunc = () => {};
@@ -142,6 +143,13 @@ describe('when class', () => {
       const newWhen = new When(mockFunc, [arg]);
       expect(newWhen.matches(1)).to.equal(true);
       expect(newWhen.matches('1')).to.equal(true);
+    });
+
+    it('should honor matcher passed in', () => {
+      const newWhen = new When(mockFunc, [any()]);
+      expect(newWhen.matches(5)).to.equal(true);
+      const mixedMatchers = new When(mockFunc, [exact(2), any(), 3]);
+      expect(mixedMatchers.matches(2, null, 3)).equal(true);
     });
   });
 

--- a/test/when/when.js
+++ b/test/when/when.js
@@ -142,10 +142,6 @@ describe('when class', () => {
       const newWhen = new When(mockFunc, [arg]);
       expect(newWhen.matches(1)).to.equal(true);
       expect(newWhen.matches('1')).to.equal(true);
-      const stringWhen = new When(mockFunc, ['1']);
-      expect(stringWhen.matches(arg)).to.equal(true);
-      const numberWhen = new When(mockFunc, [1]);
-      expect(numberWhen.matches(arg)).to.equal(true);
     });
   });
 


### PR DESCRIPTION
#### What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)

Feature
#### What is the current behavior? (You can also link to an open relevant tickets here)

There are no matchers. Whens can only match exactly on arguments.
#### What is the new behavior (if this is a feature change)?

You can use matchers to do broader stubbing. For instance the `any()` matcher will match anything.
#### Where should the reviewer start?

The matchers folder.
#### This is how I tested it

I wrote lots of tests.
#### Does this PR introduce a breaking change?

Nope.

If yes:
- [ ] Major version changed
#### Please check if the PR fulfills these requirements**
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [x] Version changed by at least patch version
