### PR TITLE
Invalidate returns with undefined values if no error is set

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mockolate",
-  "version": "3.0.0",
+  "version": "3.1.0",
   "description": "Simple mocking framework for JS",
   "main": "dist/index.js",
   "scripts": {

--- a/src/then/then.js
+++ b/src/then/then.js
@@ -61,7 +61,7 @@ class Then {
     return this.mockedFunction;
   }
   valid(){
-    return this.errorValue ? !this.returnValue : !!this.returnValue;
+    return this.errorValue ? !this.returnValue : this.returnValue !== undefined;
   }
   checkDuplicate(){
     if(this.valid()){

--- a/test/then/then.js
+++ b/test/then/then.js
@@ -24,6 +24,12 @@ describe('Then object', () => {
       expect(newThen.returnValue).to.equal('a');
     });
 
+    it('should set the return value when returning null', () => {
+      expect(newThen.return).to.be.ok;
+      newThen.return(null);
+      expect(newThen.returnValue).to.equal(null);
+    });
+
     it('should return the mocked function for chaining', () => {
       expect(newThen.return('a')).to.equal(mockFunc);
     });
@@ -117,6 +123,13 @@ describe('Then object', () => {
     it('should be valid if the return value is set', () => {
       newThen.return('a');
       expect(newThen.returnValue).to.be.ok;
+      expect(newThen.errorValue).to.not.be.ok;
+      expect(newThen.valid()).to.equal(true);
+    });
+
+    it('should be valid if the return value is null', () => {
+      newThen.return(null);
+      expect(newThen.returnValue).to.be.null;
       expect(newThen.errorValue).to.not.be.ok;
       expect(newThen.valid()).to.equal(true);
     });


### PR DESCRIPTION
#### What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)

Feature
#### What is the current behavior? (You can also link to an open relevant tickets here)

Null returns are not allowed.
#### What is the new behavior (if this is a feature change)?

Null returns are allowed.
#### Where should the reviewer start?

then/then.js
#### This is how I tested it

Existing tests covered the change.
#### Does this PR introduce a breaking change?

If yes:
- [ ] Major version changed
#### Please check if the PR fulfills these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [x] Version changed by at least patch version
